### PR TITLE
fix: default to doc_id in case of storage search otherwise use docId …

### DIFF
--- a/lib/components/state-resources/search/index.js
+++ b/lib/components/state-resources/search/index.js
@@ -330,7 +330,7 @@ class Search {
       .map(doc =>
         this.searchHistory.upsert({
           userId: userId,
-          docId: doc.docId,
+          docId: doc.doc_id || doc.docId,
           category: doc.category
         }, {})
       )


### PR DESCRIPTION
…for solr search